### PR TITLE
Fix tests gutter mark

### DIFF
--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/UnitTestExplorers/ReqnrollUnitTestProvider.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/UnitTestExplorers/ReqnrollUnitTestProvider.cs
@@ -29,7 +29,7 @@ namespace ReSharperPlugin.ReqnrollRiderPlugin.UnitTestExplorers
         }
         public bool IsSupported(IProject project, TargetFrameworkId targetFrameworkId)
         {
-            return project.GetAssemblyReferences(targetFrameworkId).Any(x => x.Name is "Reqnroll" or "TechTalk.SpecFlow");
+            return project.GetAssemblyReferences(targetFrameworkId).Any(x => x.Name == "Reqnroll" || x.Name == "TechTalk.SpecFlow");
         }
         public IUnitTestRunStrategy GetRunStrategy(IUnitTestElement element, IHostProvider hostProvider)
         {


### PR DESCRIPTION
The gutter marks were missing in Rider 2024.1.1 in my project using Specflow with the latest plugin version.

I think that the "simplify option" in Rider transformed the correct expression: 

`return project.GetAssemblyReferences(targetFrameworkId).Any(x => x.Name == "Reqnroll" || x.Name == "TechTalk.SpecFlow");`

To

 `return project.GetAssemblyReferences(targetFrameworkId).Any(x => x.Name is "Reqnroll" or "TechTalk.SpecFlow");`

(which seems incorrect to me because we want to compare the strings values).

I've build the plugin locally and it worked on my project ✅ 

      