### PR TITLE
fix navigation from test explorer #27

### DIFF
--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/ReSharperPlugin.ReqnrollRiderPlugin.Tests.csproj
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/ReSharperPlugin.ReqnrollRiderPlugin.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Reqnroll" Version="2.2.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/UnitTestExplorers/ReqnrollTestExplorerMatchingTests.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/UnitTestExplorers/ReqnrollTestExplorerMatchingTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Reflection;
+using System.Text;
+using FluentAssertions;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.UnitTestFramework;
+using JetBrains.ReSharper.UnitTestFramework.Elements;
+using JetBrains.ReSharper.UnitTestProvider.nUnit.v30;
+using Moq;
+using NUnit.Framework;
+using ReSharperPlugin.ReqnrollRiderPlugin.UnitTestExplorers;
+
+namespace ReSharperPlugin.ReqnrollRiderPlugin.Tests.UnitTestExplorers
+{
+    [TestFixture]
+    public class ReqnrollTestExplorerMatchingTests
+    {
+        private static string Identifier(string text)
+        {
+            if (text == null) return string.Empty;
+            var sb = new StringBuilder(text.Length + 4);
+            bool upperNext = true;
+            foreach (var ch in text)
+            {
+                // Remove single/double quotes
+                if (ch == '\'' || ch == '"')
+                    continue;
+
+                // Map '.', '-' and newlines to underscore like Reqnroll's ToIdentifierPart
+                if (ch == '.' || ch == '-' || ch == '\n')
+                {
+                    if (sb.Length == 0 || sb[sb.Length - 1] != '_')
+                        sb.Append('_');
+                    upperNext = true;
+                    continue;
+                }
+
+                if (char.IsLetterOrDigit(ch) || ch == '_')
+                {
+                    if (upperNext && char.IsLetter(ch))
+                        sb.Append(char.ToUpperInvariant(ch));
+                    else
+                        sb.Append(ch);
+                    upperNext = false;
+                }
+                else
+                {
+                    // Other punctuation is removed but triggers capitalization of the next letter
+                    upperNext = true;
+                }
+            }
+
+            // Ensure first char is uppercase if letter
+            if (sb.Length > 0 && char.IsLetter(sb[0]))
+                sb[0] = char.ToUpperInvariant(sb[0]);
+
+            // If first char is digit, prefix underscore like ToIdentifier
+            if (sb.Length > 0 && char.IsDigit(sb[0]))
+                sb.Insert(0, '_');
+            return sb.ToString();
+        }
+
+        private static object CreateExplorerInstance()
+        {
+            // Create instance of the internal ReqnrollTestExplorer via reflection with non-public ctor
+            var asm = typeof(ReqnrollUnitTestProvider).Assembly;
+            var type = asm.GetType("ReSharperPlugin.ReqnrollRiderPlugin.UnitTestExplorers.ReqnrollTestExplorer", throwOnError: true);
+            var instance = Activator.CreateInstance(
+                type,
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                binder: null,
+                args: new object[] { null, null, null },
+                culture: null);
+            return instance;
+        }
+
+        private static bool InvokeCompare(object explorer, string scenarioText, IUnitTestElement relatedTest)
+        {
+            var method = explorer.GetType().GetMethod("CompareDescriptionWithShortName", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull("private method must exist and be discoverable");
+            var result = method!.Invoke(explorer, new object[] { scenarioText, relatedTest });
+            return (bool)result!;
+        }
+
+        private static IUnitTestElement MakeRelatedTest(string providerId, string shortName, string? declaredShortName)
+        {
+            var providerMock = new Mock<IUnitTestProvider>(MockBehavior.Strict);
+            providerMock.SetupGet(p => p.ID).Returns(providerId);
+
+            var declaredElementMock = new Mock<IDeclaredElement>(MockBehavior.Strict);
+            declaredElementMock.SetupGet(d => d.ShortName).Returns(declaredShortName);
+
+            var elementMock = new Mock<IUnitTestElement>(MockBehavior.Strict);
+            elementMock.SetupGet(e => e.Provider).Returns(providerMock.Object);
+            elementMock.SetupGet(e => e.ShortName).Returns(shortName);
+            elementMock.Setup(e => e.GetDeclaredElement()).Returns(declaredElementMock.Object);
+
+            return elementMock.Object;
+        }
+
+        [Test]
+        public void DeclaredElementShortName_matches_scenario_identifier_any_framework()
+        {
+            var explorer = CreateExplorerInstance();
+            var scenarioText = "Add two numbers"; // identifier: AddTwoNumbers
+            var related = MakeRelatedTest(providerId: "MSTest", shortName: "Anything", declaredShortName: Identifier(scenarioText));
+
+            var matched = InvokeCompare(explorer, scenarioText, related);
+            matched.Should().BeTrue();
+        }
+
+        [Test]
+        public void NUnit_identifier_compares_against_ShortName_when_declared_not_available()
+        {
+            var explorer = CreateExplorerInstance();
+            var scenarioText = "Add two numbers"; // identifier: AddTwoNumbers
+            var related = MakeRelatedTest(providerId: NUnitTestProvider.PROVIDER_ID, shortName: Identifier(scenarioText), declaredShortName: null);
+
+            var matched = InvokeCompare(explorer, scenarioText, related);
+            matched.Should().BeTrue();
+        }
+
+        [Test]
+        public void MSTest_identifier_compares_against_ShortName_when_declared_not_available()
+        {
+            var explorer = CreateExplorerInstance();
+            var scenarioText = "Add two numbers"; // identifier: AddTwoNumbers
+            var related = MakeRelatedTest(providerId: "MSTest", shortName: Identifier(scenarioText), declaredShortName: null);
+
+            var matched = InvokeCompare(explorer, scenarioText, related);
+            matched.Should().BeTrue();
+        }
+
+        [Test]
+        public void XUnit_exact_display_name_match_succeeds()
+        {
+            var explorer = CreateExplorerInstance();
+            var scenarioText = "Title with spaces and : punctuation";
+            var related = MakeRelatedTest(providerId: "xUnit", shortName: scenarioText, declaredShortName: null);
+
+            var matched = InvokeCompare(explorer, scenarioText, related);
+            matched.Should().BeTrue();
+        }
+
+        [Test]
+        public void XUnit_identifier_fallback_works_when_display_name_differs()
+        {
+            var explorer = CreateExplorerInstance();
+            var scenarioText = "Title with special chars: star *, colon:, etc.";
+            var identifier = Identifier(scenarioText);
+            var related = MakeRelatedTest(providerId: "xUnit", shortName: identifier, declaredShortName: null);
+
+            var matched = InvokeCompare(explorer, scenarioText, related);
+            matched.Should().BeTrue();
+        }
+
+        [Test]
+        public void Mismatch_returns_false()
+        {
+            var explorer = CreateExplorerInstance();
+            var scenarioText = "One name";
+            var related = MakeRelatedTest(providerId: NUnitTestProvider.PROVIDER_ID, shortName: "DifferentName", declaredShortName: null);
+
+            var matched = InvokeCompare(explorer, scenarioText, related);
+            matched.Should().BeFalse();
+        }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/UnitTestExplorers/ReqnrollTestExplorer.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/UnitTestExplorers/ReqnrollTestExplorer.cs
@@ -17,7 +17,7 @@ using Reqnroll.Tracing;
 
 namespace ReSharperPlugin.ReqnrollRiderPlugin.UnitTestExplorers;
 
-[SolutionComponent(Instantiation.DemandAnyThreadUnsafe )]
+[SolutionComponent(Instantiation.DemandAnyThreadUnsafe)]
 internal class ReqnrollTestExplorer(
     ReqnrollUnitTestProvider unitTestProvider,
     IUnitTestElementRepository unitTestElementRepository,
@@ -80,18 +80,28 @@ internal class ReqnrollTestExplorer(
 
     private bool CompareDescriptionWithShortName(string scenarioText, IUnitTestElement relatedTest)
     {
+        var scenarioIdentifier = scenarioText.ToIdentifier();
+
+        var declaredElement = relatedTest.GetDeclaredElement();
+        var declaredShortName = declaredElement?.ShortName;
+        if (!string.IsNullOrEmpty(declaredShortName))
+        {
+            if (string.Equals(scenarioIdentifier, declaredShortName, StringComparison.InvariantCultureIgnoreCase))
+                return true;
+        }
+
         switch (relatedTest.Provider.ID)
         {
             case NUnitTestProvider.PROVIDER_ID:
             case "MSTest":
             {
-                var scenarioTextWithoutSpace = scenarioText.ToIdentifier();
-                return string.Compare(scenarioTextWithoutSpace, relatedTest.ShortName, StringComparison.InvariantCultureIgnoreCase) == 0;
-
+                return string.Compare(scenarioIdentifier, relatedTest.ShortName, StringComparison.InvariantCultureIgnoreCase) == 0;
             }
             case "xUnit":
             {
-                return scenarioText == relatedTest.ShortName;
+                if (string.Equals(scenarioText, relatedTest.ShortName, StringComparison.Ordinal))
+                    return true;
+                return string.Equals(scenarioIdentifier, relatedTest.ShortName, StringComparison.InvariantCultureIgnoreCase);
             }
         }
         return false;


### PR DESCRIPTION
### 🤔 What’s changed?

- Fixed navigation from Rider’s Test Explorer for successful Reqnroll scenarios so it opens the `.feature` file instead of the generated `.feature.cs`.
- Made scenario-to-unit-test mapping more robust across NUnit, MSTest, and xUnit by improving how the plugin compares scenario titles to discovered test elements.
- Added unit tests that cover the new matching logic including declared-element short-name matching and xUnit’s display name/identifier fallbacks.

#### Details
- In `ReqnrollTestExplorer.CompareDescriptionWithShortName`:
  - Compute `scenarioIdentifier = scenarioText.ToIdentifier()` (consistent with Reqnroll’s code generation rules).
  - First compare `scenarioIdentifier` with the declared element’s `ShortName` (this is typically the generated test method name).
  - Framework-specific fallbacks:
    - NUnit/MSTest: compare `scenarioIdentifier` with `relatedTest.ShortName` (case-insensitive).
    - xUnit: try exact `scenarioText == relatedTest.ShortName` (display name) first; if not equal, fall back to `scenarioIdentifier == relatedTest.ShortName` (case-insensitive).
- Added tests in `ReSharperPlugin.ReqnrollRiderPlugin.Tests` that verify these behaviors and ensure the identifier logic matches Reqnroll’s formatting.

### ⚡️ What’s your motivation?

Fixes a long-standing navigation bug where double‑clicking a passed scenario navigated to the generated `.feature.cs` instead of the original `.feature` file. This aligns the behavior for successful scenarios with failed scenarios, which already navigated correctly.

- Fixes: reqnroll/Reqnroll.Rider#27
- Related: JetBrains YouTrack RSRP-484008

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)
- :bank: Refactoring/debt/DX (tests and matching logic tightened without breaking API)

### ♻️ Anything particular you want feedback on?

- Edge cases for mapping scenarios to tests:
  - Scenario Outline examples with duplicate titles or parameterized names across frameworks.
  - Non‑Latin scripts and accents: current logic leans on Reqnroll’s `ToIdentifier` behavior. Any additional cases we should normalize?
  - Projects mixing multiple test frameworks in the same solution.
- Performance of matching when a feature has many scenarios and the test container has many children: current approach is `O(features * children)` but numbers are typically small. Let me know if you’ve seen large containers where we should optimize.

### 📋 Checklist

- [x] I’ve changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the CHANGELOG, linking to this pull request & included my GitHub handle to the release contributors list.