### PR TITLE
Fixed undiscovered scenario outlines when used in the rule clause

### DIFF
--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Psi/GherkinFeature.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Psi/GherkinFeature.cs
@@ -24,7 +24,8 @@ public class GherkinFeature() : GherkinElement(GherkinNodeTypes.FEATURE)
     {
         return this.Children<GherkinScenario>().Cast<IGherkinScenario>()
             .Concat(this.Children<GherkinScenarioOutline>())
-            .Concat(this.Children<GherkinRule>().SelectMany(x => x.Children<GherkinScenario>()));
+            .Concat(this.Children<GherkinRule>().SelectMany(x => x.Children<GherkinScenario>()))
+            .Concat(this.Children<GherkinRule>().SelectMany(x => x.Children<GherkinScenarioOutline>()));
     }
 
     public IList<string> GetTags()


### PR DESCRIPTION
### 🤔 What's changed?

Updated the `GetScenarios` method to correctly discovery Scenario Outline references which are under a Rule. The only two usages of this method are for the test explorer and for duplicate scenario name checking

### ⚡️ What's your motivation? 

Fixes #72 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Correctness :)

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
