### PR TITLE
Blank lines before rules

### DIFF
--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Formatting/GherkinFormatSettingsKey.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Formatting/GherkinFormatSettingsKey.cs
@@ -80,11 +80,18 @@ public class GherkinFormatSettingsKey : FormatSettingsKeyBase
     public int BlankLinesBeforeExamples { get; set; } = 1;
 
     /// <summary>
-    ///     The number of blank lines before the "Examples" clause
+    ///     The number of blank lines before the "Scenario" clause
     /// </summary>
     [EditorConfigEntryAlias("blank_lines_before_scenario", EditorConfigAliasType.LanguageSpecificStandard)]
     [SettingsEntry(1, "Blank lines before scenario")]
     public int BlankLinesBeforeScenario { get; set; } = 1;
+
+    /// <summary>
+    ///     The number of blank lines before the "Rule" clause
+    /// </summary>
+    [EditorConfigEntryAlias("blank_lines_before_rule", EditorConfigAliasType.LanguageSpecificStandard)]
+    [SettingsEntry(1, "Blank lines before rule")]
+    public int BlankLinesBeforeRule { get; set; } = 1;
 
     /// <summary>
     ///     Wrap tags on different lines

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Formatting/GherkinFormatterInfoProvider.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Formatting/GherkinFormatterInfoProvider.cs
@@ -106,6 +106,14 @@ public class GherkinFormatterInfoProvider(ISettingsSchema settingsSchema, ICalcu
             .Build();
 
         Describe<BlankLinesRule>()
+            .Name("LineBeforeRule")
+            .Group(ExtendedLineBreakGroup)
+            .Where(
+                Right().HasType(GherkinNodeTypes.RULE))
+            .SwitchBlankLines(s => s.BlankLinesBeforeRule, true, BlankLineLimitKind.LimitBothStrict)
+            .Build();
+
+        Describe<BlankLinesRule>()
             .Name("LineBetweenStepAndExamples")
             .Group(ExtendedLineBreakGroup)
             .Where(

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Formatting/GherkinFormattingStylePage.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Formatting/GherkinFormattingStylePage.cs
@@ -96,6 +96,8 @@ public class GherkinFormattingStylePageSchema(
               When I eat 5 cucumbers
               Then I should have 15 cucumbers
             
+            Rule: Cucumber rule
+            
             Scenario: PyString
               Given the following text
               """
@@ -132,6 +134,7 @@ public class GherkinFormattingStylePageSchema(
             .Category("Blank lines rules")
             .ItemFor(key => key.BlankLinesBeforeExamples, indentationExample)
             .ItemFor(key => key.BlankLinesBeforeScenario, indentationExample)
+            .ItemFor(key => key.BlankLinesBeforeRule,     indentationExample)
             .EndCategory();
 
         builder


### PR DESCRIPTION
### 🤔 What's changed?

Added ability to control the blank space before a Rule definition

### ⚡️ What's your motivation? 

Personally would like this due to formatting currently being a bit strange-looking without it

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

N/A


