### PR TITLE
Fix gutter icons for failed steps not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 2026.1.1
 - Fix comment action not working in feature files. Fixes [#75](https://github.com/reqnroll/Reqnroll.Rider/issues/75)
+- Fix gutter icons for failed steps not showing
 
 ## 2026.1.0
 - Support for Rider 2026.1

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Daemon/ExecutionFailedStep/ExecutionFailedStepGutterIconUpdater.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Daemon/ExecutionFailedStep/ExecutionFailedStepGutterIconUpdater.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using JetBrains.Application.Components;
 using JetBrains.Application.Parts;
 using JetBrains.Application.Threading;
 using JetBrains.Collections;
@@ -28,7 +29,7 @@ using GroupingEvent = JetBrains.Threading.GroupingEvent;
 namespace ReSharperPlugin.ReqnrollRiderPlugin.Daemon.ExecutionFailedStep;
 
 [SolutionComponent(Instantiation.DemandAnyThreadUnsafe)]
-public class ExecutionFailedStepGutterIconUpdater
+public class ExecutionFailedStepGutterIconUpdater : IStartupActivity
 {
     private static readonly ClrTypeName MsTestPropertyAttribute = new ClrTypeName("Microsoft.VisualStudio.TestTools.UnitTesting.TestPropertyAttribute");
     private static readonly ClrTypeName MsTestDescriptionAttribute = new ClrTypeName("Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute");


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

Restored gutter icons near failed steps after scenario run

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
