### PR TITLE
fix: #60 cucumber expression with colon

### DIFF
--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/GherkinParserTest.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/GherkinParserTest.cs
@@ -36,5 +36,7 @@ public class GherkinParserTest : ParserTestBase<GherkinLanguage>
     [TestCase("PystringWithTripleQuoteInText")]
     [TestCase("FeatureRu")]
     [TestCase("TableRowTrailingComments")]
+    [TestCase("StepWithTextStartingWithAt")]
+    [TestCase("StepWithTextStartingWithColon")]
     public void TestParser(string name) { DoOneTest(name); }
 }

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/test/data/Parsing/StepWithTextStartingWithAt.feature.gold
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/test/data/Parsing/StepWithTextStartingWithAt.feature.gold
@@ -1,5 +1,5 @@
 Language: PsiLanguageType:GHERKIN
-GherkinFile: Simple.feature
+GherkinFile: StepWithTextStartingWithAt.feature
   GherkinFeature: @Do stuff
     GherkinToken(0,7): FEATURE_KEYWORD('Feature')
     GherkinToken(7,1): COLON(':')
@@ -18,8 +18,14 @@ GherkinFile: Simple.feature
       GherkinToken(46,12): TEXT('@My scenario')
       GherkinToken(58,2): NEW_LINE('\n')
       GherkinToken(60,4): WHITE_SPACE('    ')
-      GherkinStep: something
+      GherkinStep: @something
         GherkinToken(64,5): STEP_KEYWORD('Given')
         GherkinToken(69,1): WHITE_SPACE(' ')
         GherkinToken(70,10): TEXT('@something')
+      GherkinToken(80,2): NEW_LINE('\n')
+      GherkinToken(82,4): WHITE_SPACE('    ')
+      GherkinStep: something else
+        GherkinToken(86,3): STEP_KEYWORD('And')
+        GherkinToken(89,1): WHITE_SPACE(' ')
+        GherkinToken(90,14): TEXT('something else')
 

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/test/data/Parsing/StepWithTextStartingWithColon.feature
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/test/data/Parsing/StepWithTextStartingWithColon.feature
@@ -1,0 +1,4 @@
+Feature: Colon Bug
+  Scenario: This is an example
+    Given :this step starts with a colon
+    Then the step should be recognized

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/test/data/Parsing/StepWithTextStartingWithColon.feature.gold
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin.Tests/test/data/Parsing/StepWithTextStartingWithColon.feature.gold
@@ -1,0 +1,29 @@
+Language: PsiLanguageType:GHERKIN
+GherkinFile: StepWithTextStartingWithColon.feature
+  GherkinFeature: Colon Bug
+    GherkinToken(0,7): FEATURE_KEYWORD('Feature')
+    GherkinToken(7,1): COLON(':')
+    GherkinToken(8,1): WHITE_SPACE(' ')
+    GherkinToken(9,9): TEXT('Colon Bug')
+    GherkinToken(18,1): NEW_LINE('\n')
+    GherkinToken(19,2): WHITE_SPACE('  ')
+    GherkinScenario: This is an example
+      GherkinToken(21,8): SCENARIO_KEYWORD('Scenario')
+      GherkinToken(29,1): COLON(':')
+      GherkinToken(30,1): WHITE_SPACE(' ')
+      GherkinToken(31,18): TEXT('This is an example')
+      GherkinToken(49,1): NEW_LINE('\n')
+      GherkinToken(50,4): WHITE_SPACE('    ')
+      GherkinStep: this step starts with a colon
+        GherkinToken(54,5): STEP_KEYWORD('Given')
+        GherkinToken(59,1): WHITE_SPACE(' ')
+        GherkinToken(60,1): COLON(':')
+        GherkinToken(61,29): TEXT('this step starts with a colon')
+      GherkinToken(90,1): NEW_LINE('\n')
+      GherkinToken(91,4): WHITE_SPACE('    ')
+      GherkinStep: the step should be recognized
+        GherkinToken(95,4): STEP_KEYWORD('Then')
+        GherkinToken(99,1): WHITE_SPACE(' ')
+        GherkinToken(100,29): TEXT('the step should be recognized')
+  GherkinToken(129,1): NEW_LINE('\n')
+

--- a/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Psi/GherkinParser.cs
+++ b/src/dotnet/ReSharperPlugin.ReqnrollRiderPlugin/Psi/GherkinParser.cs
@@ -247,6 +247,7 @@ public class GherkinParser : IParser
                builder.GetTokenType() == GherkinTokenTypes.STEP_PARAMETER_BRACE ||
                builder.GetTokenType() == GherkinTokenTypes.STEP_PARAMETER_TEXT ||
                builder.GetTokenType() == GherkinTokenTypes.WHITE_SPACE ||
+               builder.GetTokenType() == GherkinTokenTypes.COLON ||
                builder.GetTokenType() == GherkinTokenTypes.NEW_LINE)
         {
             if (IsLineBreak(builder))


### PR DESCRIPTION
### 🤔 What's changed?

Closes #60 there was an issue when a cucumber expression has a colon 

### ⚡️ What's your motivation? 

Fixes #60 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I'm not sure that is expected to be fix

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
